### PR TITLE
Add lens display name to the equipment tags

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -419,7 +419,7 @@ class Entry < ApplicationRecord
   def update_equipment_tags
     equipment_tags = []
     self.photos.each do |p|
-      equipment_tags << [p.camera&.make, p.camera&.display_name, p.film&.display_name]
+      equipment_tags << [p.camera&.make, p.camera&.display_name, p.lens&.display_name, p.film&.display_name]
     end
     equipment_tags = equipment_tags.flatten.uniq.reject(&:blank?)
     self.equipment_list = equipment_tags


### PR DESCRIPTION
Added lens to equipment tags so I can browse photos taken with a specific lens.

TODO (but won't do):
- add rake task to backfill tags table with lens data from existing photos
