### PR TITLE
Add and optimize social media sharing actions

### DIFF
--- a/app/controllers/admin/entries_controller.rb
+++ b/app/controllers/admin/entries_controller.rb
@@ -72,13 +72,59 @@ class Admin::EntriesController < AdminController
 
   def shareable_on_bluesky
     set_srcset
-    @entries = @photoblog.entries.published.includes(photos: [:image_attachment, :image_blob])
+    base_query = @photoblog.entries.published
       .where(post_to_bluesky: true)
       .where("last_shared_on_bluesky_at IS NULL OR last_shared_on_bluesky_at < ?", 1.year.ago)
+    @entries_count = base_query.count
+    @entries = base_query.includes(photos: [:image_attachment, :image_blob])
       .limit(10)
       .reorder(Arel.sql('RANDOM()'))
-    @entries_count = @entries.count
     @page_title = 'Shareable on Bluesky'
+    respond_to do |format|
+      format.html
+    end
+  end
+
+  def shareable_on_mastodon
+    set_srcset
+    base_query = @photoblog.entries.published
+      .where(post_to_mastodon: true)
+      .where("last_shared_on_mastodon_at IS NULL OR last_shared_on_mastodon_at < ?", 1.year.ago)
+    @entries_count = base_query.count
+    @entries = base_query.includes(photos: [:image_attachment, :image_blob])
+      .limit(10)
+      .reorder(Arel.sql('RANDOM()'))
+    @page_title = 'Shareable on Mastodon'
+    respond_to do |format|
+      format.html
+    end
+  end
+
+  def shareable_on_threads
+    set_srcset
+    base_query = @photoblog.entries.published
+      .where(post_to_threads: true)
+      .where("last_shared_on_threads_at IS NULL OR last_shared_on_threads_at < ?", 1.year.ago)
+    @entries_count = base_query.count
+    @entries = base_query.includes(photos: [:image_attachment, :image_blob])
+      .limit(10)
+      .reorder(Arel.sql('RANDOM()'))
+    @page_title = 'Shareable on Threads'
+    respond_to do |format|
+      format.html
+    end
+  end
+
+  def shareable_on_instagram
+    set_srcset
+    base_query = @photoblog.entries.published
+      .where(post_to_instagram: true)
+      .where("last_shared_on_instagram_at IS NULL OR last_shared_on_instagram_at < ?", 1.year.ago)
+    @entries_count = base_query.count
+    @entries = base_query.includes(photos: [:image_attachment, :image_blob])
+      .limit(10)
+      .reorder(Arel.sql('RANDOM()'))
+    @page_title = 'Shareable on Instagram'
     respond_to do |format|
       format.html
     end

--- a/app/views/admin/entries/shareable_on_bluesky.html.erb
+++ b/app/views/admin/entries/shareable_on_bluesky.html.erb
@@ -1,5 +1,5 @@
 <h1 class="title is-size-5-mobile">Shareable on Bluesky</h1>
-<h2 class="subtitle is-size-6-mobile">Showing <%= pluralize_with_delimiter 'entry', @entries_count %></h2>
+<h2 class="subtitle is-size-6-mobile"><%= pluralize_with_delimiter 'entry', @entries_count %></h2>
 <hr class="hr">
 <% if @entries.size == 0 %>
   <article class="message is-info">

--- a/app/views/admin/entries/shareable_on_instagram.html.erb
+++ b/app/views/admin/entries/shareable_on_instagram.html.erb
@@ -1,5 +1,5 @@
 <h1 class="title is-size-5-mobile">Shareable on Instagram</h1>
-<h2 class="subtitle is-size-6-mobile">Showing <%= pluralize_with_delimiter 'entry', @entries_count %></h2>
+<h2 class="subtitle is-size-6-mobile"><%= pluralize_with_delimiter 'entry', @entries_count %></h2>
 <hr class="hr">
 <% if @entries.size == 0 %>
   <article class="message is-info">

--- a/app/views/admin/entries/shareable_on_instagram.html.erb
+++ b/app/views/admin/entries/shareable_on_instagram.html.erb
@@ -1,0 +1,12 @@
+<h1 class="title is-size-5-mobile">Shareable on Instagram</h1>
+<h2 class="subtitle is-size-6-mobile">Showing <%= pluralize_with_delimiter 'entry', @entries_count %></h2>
+<hr class="hr">
+<% if @entries.size == 0 %>
+  <article class="message is-info">
+    <div class="message-body">
+      You don't have any entries that can be shared on Instagram. Why don't you <a href="<%= new_admin_entry_path %>">write one</a>?
+    </div>
+  </article>
+<% else %>
+  <%= render partial: 'entry', collection: @entries, cached: true %>
+<% end %>

--- a/app/views/admin/entries/shareable_on_mastodon.html.erb
+++ b/app/views/admin/entries/shareable_on_mastodon.html.erb
@@ -1,0 +1,12 @@
+<h1 class="title is-size-5-mobile">Shareable on Mastodon</h1>
+<h2 class="subtitle is-size-6-mobile">Showing <%= pluralize_with_delimiter 'entry', @entries_count %></h2>
+<hr class="hr">
+<% if @entries.size == 0 %>
+  <article class="message is-info">
+    <div class="message-body">
+      You don't have any entries that can be shared on Mastodon. Why don't you <a href="<%= new_admin_entry_path %>">write one</a>?
+    </div>
+  </article>
+<% else %>
+  <%= render partial: 'entry', collection: @entries, cached: true %>
+<% end %>

--- a/app/views/admin/entries/shareable_on_mastodon.html.erb
+++ b/app/views/admin/entries/shareable_on_mastodon.html.erb
@@ -1,5 +1,5 @@
 <h1 class="title is-size-5-mobile">Shareable on Mastodon</h1>
-<h2 class="subtitle is-size-6-mobile">Showing <%= pluralize_with_delimiter 'entry', @entries_count %></h2>
+<h2 class="subtitle is-size-6-mobile"><%= pluralize_with_delimiter 'entry', @entries_count %></h2>
 <hr class="hr">
 <% if @entries.size == 0 %>
   <article class="message is-info">

--- a/app/views/admin/entries/shareable_on_threads.html.erb
+++ b/app/views/admin/entries/shareable_on_threads.html.erb
@@ -1,0 +1,12 @@
+<h1 class="title is-size-5-mobile">Shareable on Threads</h1>
+<h2 class="subtitle is-size-6-mobile">Showing <%= pluralize_with_delimiter 'entry', @entries_count %></h2>
+<hr class="hr">
+<% if @entries.size == 0 %>
+  <article class="message is-info">
+    <div class="message-body">
+      You don't have any entries that can be shared on Threads. Why don't you <a href="<%= new_admin_entry_path %>">write one</a>?
+    </div>
+  </article>
+<% else %>
+  <%= render partial: 'entry', collection: @entries, cached: true %>
+<% end %>

--- a/app/views/admin/entries/shareable_on_threads.html.erb
+++ b/app/views/admin/entries/shareable_on_threads.html.erb
@@ -1,5 +1,5 @@
 <h1 class="title is-size-5-mobile">Shareable on Threads</h1>
-<h2 class="subtitle is-size-6-mobile">Showing <%= pluralize_with_delimiter 'entry', @entries_count %></h2>
+<h2 class="subtitle is-size-6-mobile"><%= pluralize_with_delimiter 'entry', @entries_count %></h2>
 <hr class="hr">
 <% if @entries.size == 0 %>
   <article class="message is-info">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,9 @@ Rails.application.routes.draw do
     get '/entries/tagged/:tag(/page/:page)'     => 'entries#tagged', constraints: { page: /\d+/ }, :as => 'tagged_entries'
     get '/entries/review/alt-text(/page/:page)' => 'entries#review_alt_text', constraints: { page: /\d+/ }, :as => 'review_alt_text'
     get '/entries/bluesky'            => 'entries#shareable_on_bluesky', :as => 'shareable_on_bluesky'
+    get '/entries/mastodon'           => 'entries#shareable_on_mastodon', :as => 'shareable_on_mastodon'
+    get '/entries/threads'            => 'entries#shareable_on_threads', :as => 'shareable_on_threads'
+    get '/entries/instagram'          => 'entries#shareable_on_instagram', :as => 'shareable_on_instagram'
     get '/entries/search'             => 'entries#search', :as => :search
     get '/entries/edit'               => 'entries#edit'
     get '/entries/share'              => 'entries#share'


### PR DESCRIPTION
Add actions and views for finding entries shareable on Mastodon, Threads, and Instagram, and optimize all `shareable_on_*` queries.

The queries were optimized by separating the `.count` operation from the `.includes`, `.limit`, and `.reorder` operations, preventing the loading of all matching records just to get a count.

---
<a href="https://cursor.com/background-agent?bcId=bc-21b790c7-c836-4aae-9401-b0a583f43869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-21b790c7-c836-4aae-9401-b0a583f43869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds shareable entry pages for Mastodon, Threads, and Instagram, and optimizes all shareable_on_* queries by separating count from includes/limit/reorder with randomized limited results.
> 
> - **Admin backend (`app/controllers/admin/entries_controller.rb`)**:
>   - Add `shareable_on_mastodon`, `shareable_on_threads`, `shareable_on_instagram` actions using a common pattern: published entries filtered by platform flags and last-shared timestamps, `@entries_count = base_query.count`, then `includes(...).limit(10).reorder(RANDOM())`.
>   - Refactor `shareable_on_bluesky` to the same optimized pattern.
> - **Views (`app/views/admin/entries/`)**:
>   - Add `shareable_on_mastodon.html.erb`, `shareable_on_threads.html.erb`, `shareable_on_instagram.html.erb` to list eligible entries with counts and empty-state messaging.
>   - Minor subtitle tweak in `shareable_on_bluesky.html.erb`.
> - **Routes (`config/routes.rb`)**:
>   - Add routes: `admin/entries/mastodon`, `admin/entries/threads`, `admin/entries/instagram` mapped to the new actions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75275e0cfd436a377858d423fab902d4904bd439. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->