### PR TITLE
Consolidate health checks into single endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,10 +187,10 @@ jobs:
       - name: Wait for deployment to stabilize
         run: sleep 30
 
-      - name: Check readiness endpoint
+      - name: Check health endpoint
         run: |
           curl --fail --retry 5 --retry-delay 10 --retry-all-errors \
-            https://denali.fly.dev/healthcheck/ready
+            https://denali.fly.dev/healthcheck
 
   notify-smoke-test:
     name: Notify smoke test result

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -3,15 +3,27 @@ class HealthController < ApplicationController
   skip_before_action :domain_redirect
 
   def show
-    render plain: "OK", status: :ok
-  rescue
-    render plain: "Not OK", status: :service_unavailable
-  end
-
-  def ready
+    # Check database connection
     ActiveRecord::Base.connection.execute("SELECT 1")
+
+    # Check Elasticsearch connection
+    if ENV['ELASTICSEARCH_URL'].present?
+      Elasticsearch::Model.client.ping
+    end
+
+    # Check Sidekiq Redis connection
+    if ENV["REDIS_URL"].present?
+      Sidekiq.redis(&:ping)
+    end
+
+    # Check Cache Redis connection
+    if ENV["REDIS_CACHE_URL"].present?
+      Rails.cache.redis.ping
+    end
+
     render plain: "OK", status: :ok
-  rescue StandardError
+  rescue StandardError => e
+    Rails.logger.error("Health check failed: #{e.class}: #{e.message}")
     render plain: "Not OK", status: :service_unavailable
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,7 +150,6 @@ Rails.application.routes.draw do
 
   # Miscellaneous
   get '/healthcheck'                   => 'health#show', :as => :health_check
-  get '/healthcheck/ready'             => 'health#ready', :as => :readiness_check
   get 'robots.:format'                 => 'robots#show', defaults: { format: 'txt' }
   get '*unmatched_route', to: 'errors#file_not_found'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/fly.toml
+++ b/fly.toml
@@ -30,7 +30,7 @@ console_command = '/app/bin/rails console'
   processes = ['web']
 
   [[http_service.checks]]
-    interval = '30s'
+    interval = '60s'
     timeout = '5s'
     grace_period = '10s'
     method = 'GET'


### PR DESCRIPTION
Removed the separate /healthcheck/ready endpoint and moved all health
checks into the main /healthcheck endpoint. The consolidated health
check now tests connections to:
- PostgreSQL database
- Elasticsearch
- Redis (Sidekiq)
- Redis (Cache)

This simplifies the health check infrastructure while providing more
comprehensive monitoring of all critical services.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates readiness into /healthcheck with DB/Elasticsearch/Redis checks, updates CI smoke test target, and increases Fly health check interval to 60s.
> 
> - **Health checks**:
>   - Consolidate into `GET /healthcheck`; remove `GET /healthcheck/ready` route.
>   - `HealthController#show`: verify PostgreSQL, optional Elasticsearch, Sidekiq Redis, and cache Redis; log failures and return `503` on error.
> - **CI**:
>   - Smoke test now curls `https://denali.fly.dev/healthcheck` instead of `/healthcheck/ready`.
> - **Infra (Fly.io)**:
>   - Increase HTTP health check interval from `30s` to `60s` for path `/healthcheck`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd497b4795d4d03b1a8311d86f74296a76e7987d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->