### PR TITLE
Fix health check Redis cache ping error

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -18,7 +18,7 @@ class HealthController < ApplicationController
 
     # Check Cache Redis connection
     if ENV["REDIS_CACHE_URL"].present?
-      Rails.cache.redis.ping
+      Rails.cache.redis.with(&:ping)
     end
 
     render plain: "OK", status: :ok


### PR DESCRIPTION
Rails.cache.redis returns a ConnectionPool, not a Redis client.
Use .with(&:ping) to properly get a connection from the pool.