### PR TITLE
Remove tag sitemaps from sitemap index

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -8,9 +8,6 @@ class SitemapsController < ApplicationController
     @entry_lastmods = @photoblog.entries.indexable_in_search_engines.pluck(:modified_at).each_slice(@items_per_sitemap).map { |page| page.max.strftime('%Y-%m-%dT%H:%M:%S%:z') }
     @entry_pages = [*1..total_entry_pages]
 
-    total_tag_pages = (ActsAsTaggableOn::Tag.all.count / @items_per_sitemap.to_f).ceil
-    @tag_pages = [*1..total_tag_pages]
-
     render format: 'xml'
   end
 

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -4,9 +4,9 @@ class SitemapsController < ApplicationController
   before_action :set_sitemap_item_count
 
   def index
-    total_entry_pages = (@photoblog.entries.indexable_in_search_engines.count / @items_per_sitemap.to_f).ceil
-    @entry_lastmods = @photoblog.entries.indexable_in_search_engines.pluck(:modified_at).each_slice(@items_per_sitemap).map { |page| page.max.strftime('%Y-%m-%dT%H:%M:%S%:z') }
-    @entry_pages = [*1..total_entry_pages]
+    modified_dates = @photoblog.entries.indexable_in_search_engines.pluck(:modified_at)
+    @entry_lastmods = modified_dates.each_slice(@items_per_sitemap).map { |page| page.max.strftime('%Y-%m-%dT%H:%M:%S%:z') }
+    @entry_pages = [*1..@entry_lastmods.length]
 
     render format: 'xml'
   end
@@ -19,13 +19,6 @@ class SitemapsController < ApplicationController
                          .page(@page)
                          .per(@items_per_sitemap)
     raise ActiveRecord::RecordNotFound if @entries.empty?
-    render format: 'xml'
-  end
-
-  def tags
-    @page = params[:page]
-    @tags = ActsAsTaggableOn::Tag.order('name asc').page(@page).per(@items_per_sitemap)
-    raise ActiveRecord::RecordNotFound if @tags.empty?
     render format: 'xml'
   end
 

--- a/app/views/sitemaps/index.xml.erb
+++ b/app/views/sitemaps/index.xml.erb
@@ -7,11 +7,5 @@
       <lastmod><%= @entry_lastmods[page - 1] %></lastmod>
     </sitemap>
   <% end %>
-
-  <% @tag_pages.each do |page| %>
-    <sitemap>
-      <loc><%= tags_sitemap_url(page: page) %></loc>
-    </sitemap>
-  <% end %>
 </sitemapindex>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,7 +115,6 @@ Rails.application.routes.draw do
   # Sitemaps
   get '/sitemap.:format'               => 'sitemaps#index', defaults: { format: 'xml' }, :as => :sitemap
   get '/sitemap/entries/:page.:format' => 'sitemaps#entries', constraints: { page: /\d+/ }, defaults: { format: 'xml' }, :as => :entries_sitemap
-  get '/sitemap/tags/:page.:format'    => 'sitemaps#tags', constraints: { page: /\d+/ }, defaults: { format: 'xml' }, :as => :tags_sitemap
 
   # GraphQL
   match '/graphql'                     => 'graphql#options', via: :options

--- a/test/controllers/sitemaps_controller_test.rb
+++ b/test/controllers/sitemaps_controller_test.rb
@@ -7,16 +7,6 @@ class SitemapsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "should generate tags sitemap" do
-    entry = entries(:peppers)
-    entry.tag_list = 'test'
-    entry.save
-
-    get :tags, params: { format: 'xml', page: 1 }
-    assert_template :tags
-    assert_response :success
-  end
-
   test "should generate sitemap index" do
     get :index, params: { format: 'xml' }
     assert_template :index


### PR DESCRIPTION
Tag pages are derivative content that aggregate existing entries, so including
them in the sitemap wastes crawl budget. Search engines can discover tag pages
naturally through internal linking. This change focuses the sitemap on primary
content (entries with images and proper lastmod dates) for better SEO efficiency.