### PR TITLE
Increase Redis memory to 512MB VM and 384MB maxmemory

### DIFF
--- a/fly-redis-cache/fly.toml
+++ b/fly-redis-cache/fly.toml
@@ -10,7 +10,7 @@ primary_region = 'iad'
   image = 'redis:7-alpine'
 
 [processes]
-  app = "redis-server --save '' --appendonly no --maxmemory 64mb --maxmemory-policy allkeys-lru"
+  app = "redis-server --save '' --appendonly no --maxmemory 384mb --maxmemory-policy allkeys-lru"
 
 [[services]]
   protocol = 'tcp'
@@ -26,4 +26,4 @@ primary_region = 'iad'
 [[vm]]
   cpu_kind = 'shared'
   cpus = 1
-  memory = '256mb'
+  memory = '512mb'

--- a/fly-redis-sidekiq/fly.toml
+++ b/fly-redis-sidekiq/fly.toml
@@ -10,7 +10,7 @@ primary_region = 'iad'
   image = 'redis:7-alpine'
 
 [processes]
-  app = "redis-server --save '' --appendonly no --maxmemory 64mb --maxmemory-policy noeviction"
+  app = "redis-server --save '' --appendonly no --maxmemory 384mb --maxmemory-policy noeviction"
 
 [[services]]
   protocol = 'tcp'
@@ -26,4 +26,4 @@ primary_region = 'iad'
 [[vm]]
   cpu_kind = 'shared'
   cpus = 1
-  memory = '256mb'
+  memory = '512mb'


### PR DESCRIPTION
Upgrades both Redis instances (cache and Sidekiq) from 256MB VM with
64MB maxmemory to 512MB VM with 384MB maxmemory. This should resolve
timeout issues by reducing memory pressure and cache evictions.