### PR TITLE
Fix Thumbor app disk space issue

### DIFF
--- a/fly-thumbor/nginx.conf
+++ b/fly-thumbor/nginx.conf
@@ -40,6 +40,7 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering off;
         }
 
         # Thumbor with /thumbor/ prefix
@@ -50,6 +51,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            # Disable proxy buffering to prevent disk cache buildup
+            proxy_buffering off;
+            proxy_request_buffering off;
         }
     }
 }


### PR DESCRIPTION
Disables proxy_buffering and proxy_request_buffering to prevent nginx from caching responses to disk in /var/lib/nginx/proxy, which was causing the app to run out of disk space. Since nginx and Thumbor run on the same machine, proxy caching provides minimal benefit.