### PR TITLE
Add rake task to update native lands for photos without territories

### DIFF
--- a/lib/tasks/native_lands.rake
+++ b/lib/tasks/native_lands.rake
@@ -5,4 +5,11 @@ namespace :native_lands do
       NativeLandsWorker.perform_in((2 * index).seconds, photo.id)
     end
   end
+
+  desc 'Update native lands for photos without territories'
+  task :update_missing => :environment do
+    Photo.where.missing(:photo_territories).find_each.with_index do |photo, index|
+      NativeLandsWorker.perform_in((2 * index).seconds, photo.id)
+    end
+  end
 end


### PR DESCRIPTION
This task only enqueues NativeLandsWorker jobs for photos that don't
have any associated territories, making it more efficient for backfilling
missing territory data.