### PR TITLE
Skip sharing if entry was shared recently and enable random_when_no_new_photo job

### DIFF
--- a/app/workers/random_share_worker.rb
+++ b/app/workers/random_share_worker.rb
@@ -2,6 +2,7 @@ class RandomShareWorker < ApplicationWorker
   def perform(tags, platforms, not_shared_in_months = 12, excluded_tags = [])
     return if !Rails.env.production?
     return if Entry.published.where('published_at > ?', 1.hour.ago).exists?
+    return if Entry.where('last_shared_on_bluesky_at > :time OR last_shared_on_mastodon_at > :time OR last_shared_on_instagram_at > :time OR last_shared_on_threads_at > :time', time: 1.hour.ago).exists?
     tags = Array(tags)
     platforms = Array(platforms)
     excluded_tags = Array(excluded_tags)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -28,7 +28,6 @@
       queue: high
       args: [[], ['Bluesky', 'Mastodon', 'Instagram', 'Threads'], 12, 'Cherry Blossoms']
       description: "Share a random photo on Bluesky, Mastodon, Instagram and Threads once a day at 10:01 AM ET, unless a new photo was published."
-      enabled: false
     random_once_a_day:
       cron: '0 16 * 4 *'  # Run at 4:00 PM ET every day
       class: RandomShareWorker


### PR DESCRIPTION
- Add early return in RandomShareWorker if any entry was shared on
  Bluesky, Mastodon, Instagram, or Threads in the last hour
- Enable the random_when_no_new_photo scheduled job by removing enabled: false