### PR TITLE
Handle Meta API transient errors with dedicated exception class

### DIFF
--- a/app/errors/meta_transient_error.rb
+++ b/app/errors/meta_transient_error.rb
@@ -1,0 +1,1 @@
+class MetaTransientError < StandardError; end

--- a/app/lib/instagram.rb
+++ b/app/lib/instagram.rb
@@ -94,8 +94,7 @@ class Instagram
     if response.success?
       JSON.parse(response.body)
     else
-      parsed_body = JSON.parse(response.body) rescue response.body
-      raise "Failed to post comment: #{parsed_body}"
+      raise_api_error("Failed to post comment", response)
     end
   end
 
@@ -136,7 +135,7 @@ class Instagram
     unless response.success?
       parsed_body = JSON.parse(response.body) rescue response.body
       Rails.logger.error("[Instagram] Token refresh failed: #{parsed_body}")
-      raise "Failed to refresh Instagram token: #{parsed_body}"
+      raise_api_error("Failed to refresh Instagram token", response)
     end
 
     parsed = JSON.parse(response.body)
@@ -193,8 +192,7 @@ class Instagram
     if response.success?
       JSON.parse(response.body)['id']
     else
-      parsed_body = JSON.parse(response.body) rescue response.body
-      raise "Failed to create carousel container: #{parsed_body}"
+      raise_api_error("Failed to create carousel container", response)
     end
   end
 
@@ -224,8 +222,7 @@ class Instagram
     if response.success?
       JSON.parse(response.body)['id']
     else
-      parsed_body = JSON.parse(response.body) rescue response.body
-      raise "Failed to create story container: #{parsed_body}"
+      raise_api_error("Failed to create story container", response)
     end
   end
 
@@ -249,8 +246,7 @@ class Instagram
       parsed = JSON.parse(response.body)
       parsed['status_code']
     else
-      parsed_body = JSON.parse(response.body) rescue response.body
-      raise "Failed to check container status: #{parsed_body}"
+      raise_api_error("Failed to check container status", response)
     end
   end
 
@@ -279,8 +275,7 @@ class Instagram
     if response.success?
       JSON.parse(response.body)
     else
-      parsed_body = JSON.parse(response.body) rescue response.body
-      raise "Failed to publish media: #{parsed_body}"
+      raise_api_error("Failed to publish media", response)
     end
   end
 
@@ -347,8 +342,25 @@ class Instagram
     if response.success?
       JSON.parse(response.body)['id']
     else
-      parsed_body = JSON.parse(response.body) rescue response.body
-      raise "Failed to create media container: #{parsed_body}"
+      raise_api_error("Failed to create media container", response)
+    end
+  end
+
+  # Parses an API error response and raises the appropriate error class.
+  # Raises MetaTransientError for transient errors (which Sidekiq will retry silently)
+  # and RuntimeError for all other errors (which will be reported to Bugsnag).
+  #
+  # @param message [String] a description of the failed operation.
+  # @param response [HTTParty::Response] the failed HTTP response.
+  # @raise [MetaTransientError] if the error is transient.
+  # @raise [RuntimeError] if the error is not transient.
+  def raise_api_error(message, response)
+    parsed_body = JSON.parse(response.body) rescue response.body
+    is_transient = parsed_body.is_a?(Hash) && parsed_body.dig("error", "is_transient")
+    if is_transient
+      raise MetaTransientError, "#{message}: #{parsed_body}"
+    else
+      raise "#{message}: #{parsed_body}"
     end
   end
 end

--- a/app/lib/threads.rb
+++ b/app/lib/threads.rb
@@ -101,8 +101,7 @@ class Threads
     if response.success?
       JSON.parse(response.body)['id']
     else
-      parsed_body = JSON.parse(response.body) rescue response.body
-      raise "Failed to create carousel container: #{parsed_body}"
+      raise_api_error("Failed to create carousel container", response)
     end
   end
 
@@ -124,8 +123,7 @@ class Threads
       parsed = JSON.parse(response.body)
       parsed['status']
     else
-      parsed_body = JSON.parse(response.body) rescue response.body
-      raise "Failed to check container status: #{parsed_body}"
+      raise_api_error("Failed to check container status", response)
     end
   end
 
@@ -148,8 +146,7 @@ class Threads
     if response.success?
       JSON.parse(response.body)
     else
-      parsed_body = JSON.parse(response.body) rescue response.body
-      raise "Failed to publish media: #{parsed_body}"
+      raise_api_error("Failed to publish media", response)
     end
   end
 
@@ -216,8 +213,25 @@ class Threads
     if response.success?
       JSON.parse(response.body)['id']
     else
-      parsed_body = JSON.parse(response.body) rescue response.body
-      raise "Failed to create media container: #{parsed_body}"
+      raise_api_error("Failed to create media container", response)
+    end
+  end
+
+  # Parses an API error response and raises the appropriate error class.
+  # Raises MetaTransientError for transient errors (which Sidekiq will retry silently)
+  # and RuntimeError for all other errors (which will be reported to Bugsnag).
+  #
+  # @param message [String] a description of the failed operation.
+  # @param response [HTTParty::Response] the failed HTTP response.
+  # @raise [MetaTransientError] if the error is transient.
+  # @raise [RuntimeError] if the error is not transient.
+  def raise_api_error(message, response)
+    parsed_body = JSON.parse(response.body) rescue response.body
+    is_transient = parsed_body.is_a?(Hash) && parsed_body.dig("error", "is_transient")
+    if is_transient
+      raise MetaTransientError, "#{message}: #{parsed_body}"
+    else
+      raise "#{message}: #{parsed_body}"
     end
   end
 
@@ -261,8 +275,7 @@ class Threads
     )
 
     unless response.success?
-      parsed_body = JSON.parse(response.body) rescue response.body
-      raise "Failed to refresh token: #{parsed_body}"
+      raise_api_error("Failed to refresh token", response)
     end
 
     parsed = JSON.parse(response.body)

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -3,6 +3,7 @@ Bugsnag.configure do |config|
   config.enabled_release_stages = %w[production]
   config.discard_classes += %w{
     ActiveRecord::RecordNotFound
+    MetaTransientError
     UnprocessedPhotoError
   }
 end

--- a/spec/lib/instagram_spec.rb
+++ b/spec/lib/instagram_spec.rb
@@ -233,6 +233,7 @@ RSpec.describe Instagram do
     context 'with a transient error response' do
       before do
         stub_request(:post, comments_endpoint)
+          .with(query: { message: message })
           .to_return(
             status: 400,
             body: { error: { message: 'An unexpected error has occurred.', type: 'OAuthException', is_transient: true, code: 2 } }.to_json

--- a/spec/lib/instagram_spec.rb
+++ b/spec/lib/instagram_spec.rb
@@ -229,6 +229,22 @@ RSpec.describe Instagram do
         }.to raise_error(RuntimeError, /Failed to post comment/)
       end
     end
+
+    context 'with a transient error response' do
+      before do
+        stub_request(:post, comments_endpoint)
+          .to_return(
+            status: 400,
+            body: { error: { message: 'An unexpected error has occurred.', type: 'OAuthException', is_transient: true, code: 2 } }.to_json
+          )
+      end
+
+      it 'raises MetaTransientError' do
+        expect {
+          instagram.post_comment(media_id: media_id, message: message)
+        }.to raise_error(MetaTransientError, /Failed to post comment/)
+      end
+    end
   end
 
   describe 'container status handling' do
@@ -285,6 +301,44 @@ RSpec.describe Instagram do
       it 'returns successfully' do
         response = instagram.post(photos: [photo], caption: 'Test')
         expect(response['id']).to eq('media_123')
+      end
+    end
+  end
+
+  describe 'transient error handling' do
+    let(:ig_account_id) { social_account.uid }
+    let(:media_endpoint) { "#{described_class::INSTAGRAM_GRAPH_API_BASE}/#{ig_account_id}/media" }
+    let(:instagram) { described_class.new(app_id: app_id, app_secret: app_secret, social_account: social_account) }
+
+    context 'when create_media_container returns a transient error' do
+      before do
+        stub_request(:post, media_endpoint)
+          .to_return(
+            status: 400,
+            body: { error: { message: 'An unexpected error has occurred.', type: 'OAuthException', is_transient: true, code: 2 } }.to_json
+          )
+      end
+
+      it 'raises MetaTransientError' do
+        expect {
+          instagram.post(photos: [{ url: 'https://example.com/photo.jpg', alt_text: 'Test' }], caption: 'Test')
+        }.to raise_error(MetaTransientError, /Failed to create media container/)
+      end
+    end
+
+    context 'when create_media_container returns a non-transient error' do
+      before do
+        stub_request(:post, media_endpoint)
+          .to_return(
+            status: 400,
+            body: { error: { message: 'Invalid token', type: 'OAuthException', is_transient: false, code: 190 } }.to_json
+          )
+      end
+
+      it 'raises RuntimeError' do
+        expect {
+          instagram.post(photos: [{ url: 'https://example.com/photo.jpg', alt_text: 'Test' }], caption: 'Test')
+        }.to raise_error(RuntimeError, /Failed to create media container/)
       end
     end
   end

--- a/spec/lib/threads_spec.rb
+++ b/spec/lib/threads_spec.rb
@@ -228,6 +228,45 @@ RSpec.describe Threads do
     end
   end
 
+  describe 'transient error handling' do
+    let(:threads_endpoint) { "#{described_class::THREADS_API_BASE}/#{threads_user_id}/threads" }
+    let(:threads) { described_class.new(app_id: app_id, app_secret: app_secret, social_account: social_account) }
+
+    context 'when create_media_container returns a transient error' do
+      before do
+        stub_request(:post, threads_endpoint)
+          .with(query: hash_including(access_token: access_token))
+          .to_return(
+            status: 400,
+            body: { error: { message: 'An unexpected error has occurred.', type: 'OAuthException', is_transient: true, code: 2 } }.to_json
+          )
+      end
+
+      it 'raises MetaTransientError' do
+        expect {
+          threads.post(photos: [{ url: 'https://example.com/photo.jpg', alt_text: 'Test' }], caption: 'Test')
+        }.to raise_error(MetaTransientError, /Failed to create media container/)
+      end
+    end
+
+    context 'when create_media_container returns a non-transient error' do
+      before do
+        stub_request(:post, threads_endpoint)
+          .with(query: hash_including(access_token: access_token))
+          .to_return(
+            status: 400,
+            body: { error: { message: 'Invalid token', type: 'OAuthException', is_transient: false, code: 190 } }.to_json
+          )
+      end
+
+      it 'raises RuntimeError' do
+        expect {
+          threads.post(photos: [{ url: 'https://example.com/photo.jpg', alt_text: 'Test' }], caption: 'Test')
+        }.to raise_error(RuntimeError, /Failed to create media container/)
+      end
+    end
+  end
+
   describe 'constants' do
     it 'has correct API base URLs' do
       expect(described_class::THREADS_API_BASE).to eq('https://graph.threads.net/v1.0')


### PR DESCRIPTION
## Summary
This PR introduces proper handling of transient errors from Meta's Instagram and Threads APIs by creating a dedicated `MetaTransientError` exception class. Transient errors are now distinguished from permanent errors, allowing Sidekiq to automatically retry failed operations without reporting them to error tracking services.

## Key Changes
- **New error class**: Created `MetaTransientError` to represent temporary API failures that should be retried
- **Centralized error handling**: Added `raise_api_error` method to both `Instagram` and `Threads` classes that:
  - Parses API responses to check the `is_transient` flag
  - Raises `MetaTransientError` for transient errors (which Sidekiq will retry silently)
  - Raises `RuntimeError` for permanent errors (which will be reported to Bugsnag)
- **Refactored error raising**: Replaced inline error handling in 10+ methods across both classes with calls to the new `raise_api_error` method
- **Bugsnag configuration**: Added `MetaTransientError` to the discard list so transient errors don't clutter error tracking
- **Comprehensive test coverage**: Added test cases for both transient and non-transient error scenarios in Instagram and Threads specs

## Implementation Details
The `raise_api_error` method safely parses the JSON response body and checks for the `is_transient` flag in the error object. This allows the application to gracefully handle temporary API issues (rate limiting, service unavailability, etc.) without alerting the team, while still reporting genuine failures that require investigation.

https://claude.ai/code/session_0189wMHL2epxnLhr9GzLs5ek