### PR TITLE
Add logging for Instagram and Threads media container creation

### DIFF
--- a/app/lib/instagram.rb
+++ b/app/lib/instagram.rb
@@ -213,6 +213,8 @@ class Instagram
       'Authorization' => "Bearer #{access_token}"
     }
 
+    Rails.logger.info("[Instagram] Creating story container with image_url: #{photo_url}")
+
     response = HTTParty.post(
       "#{INSTAGRAM_GRAPH_API_BASE}/#{@ig_account_id}/media",
       body: body.to_json,
@@ -222,6 +224,7 @@ class Instagram
     if response.success?
       JSON.parse(response.body)['id']
     else
+      Rails.logger.error("[Instagram] Failed to create story container. image_url: #{photo_url}")
       raise_api_error("Failed to create story container", response)
     end
   end
@@ -333,6 +336,8 @@ class Instagram
       'Authorization' => "Bearer #{access_token}"
     }
 
+    Rails.logger.info("[Instagram] Creating media container with image_url: #{image_url}")
+
     response = HTTParty.post(
       "#{INSTAGRAM_GRAPH_API_BASE}/#{@ig_account_id}/media",
       body: body.to_json,
@@ -342,6 +347,7 @@ class Instagram
     if response.success?
       JSON.parse(response.body)['id']
     else
+      Rails.logger.error("[Instagram] Failed to create media container. image_url: #{image_url}")
       raise_api_error("Failed to create media container", response)
     end
   end

--- a/app/lib/threads.rb
+++ b/app/lib/threads.rb
@@ -204,6 +204,8 @@ class Threads
       location_id: location_id
     }.compact
 
+    Rails.logger.info("[Threads] Creating media container with image_url: #{image_url}")
+
     response = HTTParty.post(
       "#{THREADS_API_BASE}/#{@threads_user_id}/threads",
       body: body,
@@ -213,6 +215,7 @@ class Threads
     if response.success?
       JSON.parse(response.body)['id']
     else
+      Rails.logger.error("[Threads] Failed to create media container. image_url: #{image_url}")
       raise_api_error("Failed to create media container", response)
     end
   end


### PR DESCRIPTION
## Summary
Added structured logging to track media container creation attempts and failures in both Instagram and Threads API integrations.

## Key Changes
- **Instagram API (`app/lib/instagram.rb`)**
  - Added info-level log when creating story containers with image URL
  - Added error-level log when story container creation fails
  - Added info-level log when creating media containers with image URL
  - Added error-level log when media container creation fails

- **Threads API (`app/lib/threads.rb`)**
  - Added info-level log when creating media containers with image URL
  - Added error-level log when media container creation fails

## Implementation Details
- Logs include the image URL for debugging purposes, allowing developers to trace which images caused failures
- Info logs are emitted before API requests to track creation attempts
- Error logs are emitted in failure paths before raising exceptions
- Consistent logging format across both integrations using `[Service Name]` prefix for easy filtering

https://claude.ai/code/session_01MHg8Nahy7HxmzhZXoZyBpL