### PR TITLE
Add media proxy endpoint for social sharing

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,0 +1,24 @@
+class MediaController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  before_action :no_cache
+
+  STYLES = {
+    'instagram' => :instagram_url,
+    'instagram_story' => :instagram_story_url,
+    'threads' => :threads_url
+  }.freeze
+
+  def show
+    photo = Photo.find(params[:photo_id])
+    style = STYLES[params[:style]]
+    raise ActionController::RoutingError.new('Not Found') unless style
+
+    url = if style == :instagram_story_url
+      photo.instagram_story_url(crop: params[:crop] == 'true')
+    else
+      photo.send(style)
+    end
+
+    redirect_to url, allow_other_host: true
+  end
+end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -1,6 +1,5 @@
 class MediaController < ApplicationController
   skip_before_action :verify_authenticity_token
-  before_action :no_cache
 
   STYLES = {
     'instagram' => :instagram_url,
@@ -19,6 +18,8 @@ class MediaController < ApplicationController
       photo.send(style)
     end
 
-    redirect_to url, allow_other_host: true
+    image_response = HTTParty.get(url)
+    set_max_age
+    send_data image_response.body, type: image_response.content_type, disposition: 'inline'
   end
 end

--- a/app/jobs/instagram_job.rb
+++ b/app/jobs/instagram_job.rb
@@ -18,7 +18,7 @@ class InstagramJob < ApplicationJob
       social_account: instagram_account
     )
 
-    photos = entry.photos.limit(10).map { |p| { url: p.instagram_url, alt_text: p.alt_text } }
+    photos = entry.photos.limit(10).map { |p| { url: p.instagram_media_redirect_url, alt_text: p.alt_text } }
     location_id = entry.photos.first.instagram_location_id
 
     response = instagram.post(

--- a/app/jobs/instagram_story_job.rb
+++ b/app/jobs/instagram_story_job.rb
@@ -23,7 +23,7 @@ class InstagramStoryJob < ApplicationJob
     return if photo.blank?
 
     instagram.post_story(
-      photo_url: photo.instagram_story_url(crop: crop)
+      photo_url: photo.instagram_story_media_redirect_url(crop: crop)
     )
   end
 end

--- a/app/jobs/threads_job.rb
+++ b/app/jobs/threads_job.rb
@@ -20,7 +20,7 @@ class ThreadsJob < ApplicationJob
 
     photos = entry.photos.limit(20).map do |p|
       {
-        url: p.threads_url,
+        url: p.threads_media_redirect_url,
         alt_text: p.alt_text
       }
     end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -154,6 +154,18 @@ class Photo < ApplicationRecord
     self.url(opts)
   end
 
+  def instagram_media_redirect_url
+    Rails.application.routes.url_helpers.photo_media_url(photo_id: self.id, style: 'instagram')
+  end
+
+  def instagram_story_media_redirect_url(crop: false)
+    Rails.application.routes.url_helpers.photo_media_url(photo_id: self.id, style: 'instagram_story', crop: crop)
+  end
+
+  def threads_media_redirect_url
+    Rails.application.routes.url_helpers.photo_media_url(photo_id: self.id, style: 'threads')
+  end
+
   def bluesky_url
     width = self.is_vertical? ? width_from_height(2000) : 2000
     opts = { width: width, format: 'jpeg', quality: 60 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,6 +164,9 @@ Rails.application.routes.draw do
   get '/about'                         => 'blogs#about', as: :about
   get '/elsewhere', to: redirect('/about', status: 301)
 
+  # Media redirects for social sharing
+  get '/photos/:photo_id/media/:style' => 'media#show', as: :photo_media
+
   # Miscellaneous
   get '/healthcheck'                   => 'health#show', as: :health_check
   get 'robots.:format'                 => 'robots#show', defaults: { format: 'txt' }

--- a/spec/jobs/instagram_story_job_spec.rb
+++ b/spec/jobs/instagram_story_job_spec.rb
@@ -42,10 +42,10 @@ RSpec.describe InstagramStoryJob, type: :worker do
     it 'posts story to Instagram' do
       instagram = instance_double(Instagram)
       allow(Instagram).to receive(:new).and_return(instagram)
-      allow_any_instance_of(Photo).to receive(:instagram_story_url).and_return('https://example.com/photo.jpg')
+      allow_any_instance_of(Photo).to receive(:instagram_story_media_redirect_url).and_return('https://example.com/photos/1/media/instagram_story')
 
       expect(instagram).to receive(:post_story).with(
-        hash_including(photo_url: 'https://example.com/photo.jpg')
+        hash_including(photo_url: 'https://example.com/photos/1/media/instagram_story')
       )
 
       described_class.new.perform(entry.id)
@@ -54,7 +54,7 @@ RSpec.describe InstagramStoryJob, type: :worker do
     it 'initializes Instagram with the connected social account' do
       instagram = instance_double(Instagram)
       allow(instagram).to receive(:post_story)
-      allow_any_instance_of(Photo).to receive(:instagram_story_url).and_return('https://example.com/photo.jpg')
+      allow_any_instance_of(Photo).to receive(:instagram_story_media_redirect_url).and_return('https://example.com/photos/1/media/instagram_story')
 
       expect(Instagram).to receive(:new).with(
         app_id: 'app_id',
@@ -70,7 +70,7 @@ RSpec.describe InstagramStoryJob, type: :worker do
       allow(Instagram).to receive(:new).and_return(instagram)
       allow(instagram).to receive(:post_story)
 
-      expect_any_instance_of(Photo).to receive(:instagram_story_url).with(crop: true)
+      expect_any_instance_of(Photo).to receive(:instagram_story_media_redirect_url).with(crop: true)
       described_class.new.perform(entry.id, true)
     end
   end

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe "Media", type: :request do
+  let!(:blog) { Blog.first || create(:blog) }
+  let(:user) { create(:user) }
+  let(:entry) { create(:entry, :published, :with_photo, blog: blog, user: user) }
+  let(:photo) { entry.photos.first }
+
+  before do
+    attach_image_to_photo(photo)
+  end
+
+  describe "GET /photos/:photo_id/media/:style" do
+    it "redirects to the instagram thumbor URL" do
+      get photo_media_path(photo_id: photo.id, style: 'instagram')
+      expect(response).to have_http_status(:redirect)
+      expect(response.location).to eq(photo.instagram_url)
+    end
+
+    it "redirects to the threads thumbor URL" do
+      get photo_media_path(photo_id: photo.id, style: 'threads')
+      expect(response).to have_http_status(:redirect)
+      expect(response.location).to eq(photo.threads_url)
+    end
+
+    it "redirects to the instagram story thumbor URL" do
+      get photo_media_path(photo_id: photo.id, style: 'instagram_story')
+      expect(response).to have_http_status(:redirect)
+      expect(response.location).to eq(photo.instagram_story_url)
+    end
+
+    it "redirects to the cropped instagram story thumbor URL" do
+      get photo_media_path(photo_id: photo.id, style: 'instagram_story', crop: 'true')
+      expect(response).to have_http_status(:redirect)
+      expect(response.location).to eq(photo.instagram_story_url(crop: true))
+    end
+
+    it "returns 404 for an invalid style" do
+      expect {
+        get photo_media_path(photo_id: photo.id, style: 'invalid')
+      }.to raise_error(ActionController::RoutingError)
+    end
+
+    it "returns 404 for a non-existent photo" do
+      expect {
+        get photo_media_path(photo_id: 0, style: 'instagram')
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -49,15 +49,13 @@ RSpec.describe "Media", type: :request do
     end
 
     it "returns 404 for an invalid style" do
-      expect {
-        get photo_media_path(photo_id: photo.id, style: 'invalid')
-      }.to raise_error(ActionController::RoutingError)
+      get photo_media_path(photo_id: photo.id, style: 'invalid')
+      expect(response).to have_http_status(:not_found)
     end
 
     it "returns 404 for a non-existent photo" do
-      expect {
-        get photo_media_path(photo_id: 0, style: 'instagram')
-      }.to raise_error(ActiveRecord::RecordNotFound)
+      get photo_media_path(photo_id: 0, style: 'instagram')
+      expect(response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -5,34 +5,47 @@ RSpec.describe "Media", type: :request do
   let(:user) { create(:user) }
   let(:entry) { create(:entry, :published, :with_photo, blog: blog, user: user) }
   let(:photo) { entry.photos.first }
+  let(:image_body) { File.read(Rails.root.join('spec/fixtures/images/rusty.jpg'), mode: 'rb') }
 
   before do
     attach_image_to_photo(photo)
+    stub_request(:get, /#{ENV['THUMBOR_DOMAIN']}/).to_return(
+      status: 200,
+      body: image_body,
+      headers: { 'Content-Type' => 'image/jpeg' }
+    )
   end
 
   describe "GET /photos/:photo_id/media/:style" do
-    it "redirects to the instagram thumbor URL" do
+    it "serves the instagram image" do
       get photo_media_path(photo_id: photo.id, style: 'instagram')
-      expect(response).to have_http_status(:redirect)
-      expect(response.location).to eq(photo.instagram_url)
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include('image/jpeg')
+      expect(response.body).to eq(image_body)
     end
 
-    it "redirects to the threads thumbor URL" do
+    it "serves the threads image" do
       get photo_media_path(photo_id: photo.id, style: 'threads')
-      expect(response).to have_http_status(:redirect)
-      expect(response.location).to eq(photo.threads_url)
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include('image/jpeg')
     end
 
-    it "redirects to the instagram story thumbor URL" do
+    it "serves the instagram story image" do
       get photo_media_path(photo_id: photo.id, style: 'instagram_story')
-      expect(response).to have_http_status(:redirect)
-      expect(response.location).to eq(photo.instagram_story_url)
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include('image/jpeg')
     end
 
-    it "redirects to the cropped instagram story thumbor URL" do
+    it "serves the cropped instagram story image" do
       get photo_media_path(photo_id: photo.id, style: 'instagram_story', crop: 'true')
-      expect(response).to have_http_status(:redirect)
-      expect(response.location).to eq(photo.instagram_story_url(crop: true))
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include('image/jpeg')
+    end
+
+    it "sets cache headers" do
+      get photo_media_path(photo_id: photo.id, style: 'instagram')
+      expect(response.headers['Cache-Control']).to include('s-maxage')
+      expect(response.headers['Cache-Control']).to include('public')
     end
 
     it "returns 404 for an invalid style" do


### PR DESCRIPTION
## Summary

- Meta's Instagram and Threads APIs started failing to fetch images from Thumbor URLs (error subcode 2207052 — "media download has failed")
- Adds a new `GET /photos/:photo_id/media/:style` endpoint that fetches the image from Thumbor and serves it directly, giving Meta a short, clean URL that returns image bytes
- Updates Instagram, Instagram Story, and Threads jobs to pass the proxy URL instead of the raw Thumbor URL
- Supported styles: `instagram`, `instagram_story` (with optional `?crop=true`), `threads`
- Responses are cached using default cache headers

## Test plan

- [ ] Run `bundle exec rspec spec/requests/media_spec.rb` to verify the new endpoint
- [ ] Run `bundle exec rspec spec/jobs/instagram_story_job_spec.rb` to verify updated job specs
- [ ] Run full test suite to check for regressions
- [ ] Deploy and test sharing a photo to Instagram and Threads to confirm Meta can fetch images from the new endpoint

https://claude.ai/code/session_01MHg8Nahy7HxmzhZXoZyBpL