### PR TITLE
Add 1 hour retry window to social media posting jobs

### DIFF
--- a/app/jobs/bluesky_job.rb
+++ b/app/jobs/bluesky_job.rb
@@ -1,5 +1,5 @@
 class BlueskyJob < ApplicationJob
-  sidekiq_options queue: 'high'
+  sidekiq_options queue: 'high', retry_for: 1.hour
 
   def perform(entry_id, text, in_reply_to = nil, quote = nil)
     return unless Rails.env.production?

--- a/app/jobs/instagram_job.rb
+++ b/app/jobs/instagram_job.rb
@@ -1,5 +1,5 @@
 class InstagramJob < ApplicationJob
-  sidekiq_options queue: 'high'
+  sidekiq_options queue: 'high', retry_for: 1.hour
 
   def perform(entry_id, text)
     return if !Rails.env.production?

--- a/app/jobs/instagram_story_job.rb
+++ b/app/jobs/instagram_story_job.rb
@@ -1,5 +1,5 @@
 class InstagramStoryJob < ApplicationJob
-  sidekiq_options queue: 'high'
+  sidekiq_options queue: 'high', retry_for: 1.hour
 
   def perform(entry_id, crop = false)
     return if !Rails.env.production?

--- a/app/jobs/mastodon_job.rb
+++ b/app/jobs/mastodon_job.rb
@@ -1,5 +1,5 @@
 class MastodonJob < ApplicationJob
-  sidekiq_options queue: 'high'
+  sidekiq_options queue: 'high', retry_for: 1.hour
 
   def perform(entry_id, text)
     return unless Rails.env.production?

--- a/app/jobs/threads_job.rb
+++ b/app/jobs/threads_job.rb
@@ -1,5 +1,5 @@
 class ThreadsJob < ApplicationJob
-  sidekiq_options queue: 'high'
+  sidekiq_options queue: 'high', retry_for: 1.hour
 
   def perform(entry_id, text)
     return if !Rails.env.production?


### PR DESCRIPTION
## Summary
Updated all social media posting jobs to include a retry window of 1 hour, allowing failed job attempts to be retried within that timeframe before being permanently discarded.

## Changes
- **BlueskyJob**: Added `retry_for: 1.hour` to sidekiq_options
- **InstagramJob**: Added `retry_for: 1.hour` to sidekiq_options
- **InstagramStoryJob**: Added `retry_for: 1.hour` to sidekiq_options
- **MastodonJob**: Added `retry_for: 1.hour` to sidekiq_options
- **ThreadsJob**: Added `retry_for: 1.hour` to sidekiq_options

## Details
This change improves reliability for social media posting operations by giving failed jobs a grace period to retry. If a social media API is temporarily unavailable or a network issue occurs, the job will automatically retry within the 1-hour window instead of failing immediately. This is particularly useful for these high-priority jobs that post to external platforms.

https://claude.ai/code/session_01U48VCXKYgZ6Q656uuCXSVQ