### PR TITLE
Discard ThreadsJob immediately when caption exceeds 500 characters

### DIFF
--- a/app/errors/meta_caption_too_long_error.rb
+++ b/app/errors/meta_caption_too_long_error.rb
@@ -1,0 +1,1 @@
+class MetaCaptionTooLongError < StandardError; end

--- a/app/jobs/threads_job.rb
+++ b/app/jobs/threads_job.rb
@@ -1,5 +1,6 @@
 class ThreadsJob < ApplicationJob
   sidekiq_options queue: 'high', retry_for: 1.hour
+  discard_on MetaCaptionTooLongError
 
   def perform(entry_id, text)
     return if !Rails.env.production?

--- a/app/lib/threads.rb
+++ b/app/lib/threads.rb
@@ -234,10 +234,13 @@ class Threads
     parsed_body = JSON.parse(response.body) rescue response.body
     is_transient = parsed_body.is_a?(Hash) && parsed_body.dig("error", "is_transient")
     error_subcode = parsed_body.is_a?(Hash) && parsed_body.dig("error", "error_subcode")
+    error_message = parsed_body.is_a?(Hash) && parsed_body.dig("error", "message").to_s
     if is_transient
       raise MetaTransientError, "#{message}: #{parsed_body}"
     elsif error_subcode == 2207052
       raise MetaMediaDownloadError, "#{message}: #{parsed_body}"
+    elsif error_message.match?(/must be at most \d+ characters long/i)
+      raise MetaCaptionTooLongError, "#{message}: #{parsed_body}"
     else
       raise "#{message}: #{parsed_body}"
     end

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -3,6 +3,7 @@ Bugsnag.configure do |config|
   config.enabled_release_stages = %w[production]
   config.discard_classes += %w{
     ActiveRecord::RecordNotFound
+    MetaCaptionTooLongError
     MetaMediaDownloadError
     MetaTransientError
     UnprocessedPhotoError

--- a/spec/lib/threads_spec.rb
+++ b/spec/lib/threads_spec.rb
@@ -266,6 +266,23 @@ RSpec.describe Threads do
       end
     end
 
+    context 'when create_media_container returns a caption too long error' do
+      before do
+        stub_request(:post, threads_endpoint)
+          .with(query: hash_including(access_token: access_token))
+          .to_return(
+            status: 400,
+            body: { error: { message: 'Param text must be at most 500 characters long.', type: 'THApiException', code: 100 } }.to_json
+          )
+      end
+
+      it 'raises MetaCaptionTooLongError' do
+        expect {
+          threads.post(photos: [{ url: 'https://example.com/photo.jpg', alt_text: 'Test' }], caption: 'x' * 501)
+        }.to raise_error(MetaCaptionTooLongError, /Failed to create media container/)
+      end
+    end
+
     context 'when create_media_container returns a non-transient error' do
       before do
         stub_request(:post, threads_endpoint)


### PR DESCRIPTION
The Threads API returns error code 100 when the caption text exceeds
the 500 character limit. Since the caption length can't be changed on
retry, the job should fail immediately instead of retrying for an hour.

https://claude.ai/code/session_01QfSxAnXjoxS2KskvHVpc2h