### PR TITLE
Replace discard_on with sidekiq_retry_in for MetaCaptionTooLongError

### DIFF
--- a/app/jobs/threads_job.rb
+++ b/app/jobs/threads_job.rb
@@ -1,6 +1,9 @@
 class ThreadsJob < ApplicationJob
   sidekiq_options queue: 'high', retry_for: 1.hour
-  discard_on MetaCaptionTooLongError
+
+  sidekiq_retry_in do |_count, exception|
+    :discard if exception.is_a?(MetaCaptionTooLongError)
+  end
 
   def perform(entry_id, text)
     return if !Rails.env.production?


### PR DESCRIPTION
## Summary
Updated the error handling strategy in ThreadsJob to use Sidekiq's `sidekiq_retry_in` callback instead of the `discard_on` method for handling `MetaCaptionTooLongError` exceptions.

## Key Changes
- Replaced `discard_on MetaCaptionTooLongError` with a `sidekiq_retry_in` block that discards jobs when this exception is encountered
- The new implementation provides more explicit control over the retry/discard behavior using Sidekiq's retry callback mechanism

## Implementation Details
- The `sidekiq_retry_in` callback receives the retry count and exception as parameters
- Returns `:discard` when the exception is a `MetaCaptionTooLongError`, immediately discarding the job without further retries
- This approach is more flexible than `discard_on` as it allows for conditional logic based on exception type and retry count if needed in the future

https://claude.ai/code/session_01GbCJL4biYsMRnh16J1x4Ae