### PR TITLE
Generate preview_hash with SecureRandom

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -976,8 +976,7 @@ class Entry < ApplicationRecord
 
   def set_preview_hash
     if self.preview_hash.blank?
-      md5 = Digest::MD5.new
-      self.preview_hash = md5.hexdigest(Time.current.to_i.to_s)
+      self.preview_hash = SecureRandom.hex(16)
     end
   end
 


### PR DESCRIPTION
The previous implementation hashed a Unix timestamp with MD5, which
meant the preview URL for unpublished entries was derived from only
~31M possible values per year and could be brute-forced to access
drafts via the unauthenticated /preview/:preview_hash route.

https://claude.ai/code/session_01BfxQjTvNj4RYzFh9v1NuXa