### PR TITLE
Raise Bluesky image limit to 4000px

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -155,7 +155,14 @@ class Photo < ApplicationRecord
   end
 
   def bluesky_url
-    width = self.is_vertical? ? width_from_height(2000) : 2000
+    max_dimension = 4000
+    width = if self.is_vertical?
+      width_from_height([self.height, max_dimension].min)
+    elsif has_dimensions?
+      [self.width, max_dimension].min
+    else
+      max_dimension
+    end
     opts = { width: width, format: 'jpeg', quality: 60 }
     self.url(opts)
   end

--- a/spec/models/photo_spec.rb
+++ b/spec/models/photo_spec.rb
@@ -178,6 +178,56 @@ RSpec.describe Photo, type: :model do
     end
   end
 
+  describe '#bluesky_url' do
+    let(:photo) { create(:photo, entry: entry) }
+
+    it 'requests 4000px wide for a horizontal photo larger than 4000px' do
+      allow(photo).to receive(:width).and_return(6000)
+      allow(photo).to receive(:height).and_return(4000)
+      allow(photo).to receive(:has_dimensions?).and_return(true)
+
+      expect(photo).to receive(:url).with(hash_including(width: 4000, format: 'jpeg', quality: 60))
+      photo.bluesky_url
+    end
+
+    it 'does not upscale a horizontal photo smaller than 4000px' do
+      allow(photo).to receive(:width).and_return(3000)
+      allow(photo).to receive(:height).and_return(2000)
+      allow(photo).to receive(:has_dimensions?).and_return(true)
+
+      expect(photo).to receive(:url).with(hash_including(width: 3000, format: 'jpeg', quality: 60))
+      photo.bluesky_url
+    end
+
+    it 'scales a vertical photo taller than 4000px to fit 4000px height' do
+      allow(photo).to receive(:width).and_return(4000)
+      allow(photo).to receive(:height).and_return(6000)
+      allow(photo).to receive(:has_dimensions?).and_return(true)
+
+      expected_width = photo.width_from_height(4000)
+      expect(photo).to receive(:url).with(hash_including(width: expected_width, format: 'jpeg', quality: 60))
+      photo.bluesky_url
+    end
+
+    it 'does not upscale a vertical photo shorter than 4000px' do
+      allow(photo).to receive(:width).and_return(2000)
+      allow(photo).to receive(:height).and_return(3000)
+      allow(photo).to receive(:has_dimensions?).and_return(true)
+
+      expect(photo).to receive(:url).with(hash_including(width: 2000, format: 'jpeg', quality: 60))
+      photo.bluesky_url
+    end
+
+    it 'falls back to 4000px when dimensions are unknown' do
+      allow(photo).to receive(:width).and_return(nil)
+      allow(photo).to receive(:height).and_return(nil)
+      allow(photo).to receive(:has_dimensions?).and_return(false)
+
+      expect(photo).to receive(:url).with(hash_including(width: 4000, format: 'jpeg', quality: 60))
+      photo.bluesky_url
+    end
+  end
+
   describe 'location helpers' do
     describe '#has_location?' do
       it 'returns false when coordinates are missing' do


### PR DESCRIPTION
Bluesky now accepts images up to 4000x4000
(https://bsky.app/profile/bsky.app/post/3mk4lzkrnk22d), so request a larger target dimension when generating the URL for Bluesky uploads. Cap the target at the photo's native longest dimension so smaller images aren't upscaled.