### PR TITLE
Cap Bluesky image uploads under the 2MB blob limit

### DIFF
--- a/app/models/concerns/thumborizable.rb
+++ b/app/models/concerns/thumborizable.rb
@@ -23,6 +23,7 @@ module Thumborizable
     filters = []
     filters << "fill(#{opts[:fill]},true)" if opts[:fill].present?
     filters << "quality(#{opts[:quality]})" if opts[:quality].present?
+    filters << "max_bytes(#{opts[:max_bytes]})" if opts[:max_bytes].present?
     filters << "grayscale()" if opts[:grayscale].present?
     filters << "format(#{opts[:format]})" if opts[:format].present? && VALID_FORMATS.include?(opts[:format])
     filters

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -163,7 +163,7 @@ class Photo < ApplicationRecord
     else
       max_dimension
     end
-    opts = { width: width, format: 'jpeg', quality: 60 }
+    opts = { width: width, format: 'jpeg', quality: 80, max_bytes: 1_950_000 }
     self.url(opts)
   end
 

--- a/spec/models/photo_spec.rb
+++ b/spec/models/photo_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe Photo, type: :model do
       allow(photo).to receive(:height).and_return(4000)
       allow(photo).to receive(:has_dimensions?).and_return(true)
 
-      expect(photo).to receive(:url).with(hash_including(width: 4000, format: 'jpeg', quality: 60))
+      expect(photo).to receive(:url).with(hash_including(width: 4000, format: 'jpeg', quality: 80, max_bytes: 1_950_000))
       photo.bluesky_url
     end
 
@@ -195,7 +195,7 @@ RSpec.describe Photo, type: :model do
       allow(photo).to receive(:height).and_return(2000)
       allow(photo).to receive(:has_dimensions?).and_return(true)
 
-      expect(photo).to receive(:url).with(hash_including(width: 3000, format: 'jpeg', quality: 60))
+      expect(photo).to receive(:url).with(hash_including(width: 3000, format: 'jpeg', quality: 80, max_bytes: 1_950_000))
       photo.bluesky_url
     end
 
@@ -205,7 +205,7 @@ RSpec.describe Photo, type: :model do
       allow(photo).to receive(:has_dimensions?).and_return(true)
 
       expected_width = photo.width_from_height(4000)
-      expect(photo).to receive(:url).with(hash_including(width: expected_width, format: 'jpeg', quality: 60))
+      expect(photo).to receive(:url).with(hash_including(width: expected_width, format: 'jpeg', quality: 80, max_bytes: 1_950_000))
       photo.bluesky_url
     end
 
@@ -214,7 +214,7 @@ RSpec.describe Photo, type: :model do
       allow(photo).to receive(:height).and_return(3000)
       allow(photo).to receive(:has_dimensions?).and_return(true)
 
-      expect(photo).to receive(:url).with(hash_including(width: 2000, format: 'jpeg', quality: 60))
+      expect(photo).to receive(:url).with(hash_including(width: 2000, format: 'jpeg', quality: 80, max_bytes: 1_950_000))
       photo.bluesky_url
     end
 
@@ -223,7 +223,7 @@ RSpec.describe Photo, type: :model do
       allow(photo).to receive(:height).and_return(nil)
       allow(photo).to receive(:has_dimensions?).and_return(false)
 
-      expect(photo).to receive(:url).with(hash_including(width: 4000, format: 'jpeg', quality: 60))
+      expect(photo).to receive(:url).with(hash_including(width: 4000, format: 'jpeg', quality: 80, max_bytes: 1_950_000))
       photo.bluesky_url
     end
   end


### PR DESCRIPTION
## Summary

Bluesky rejects `app.bsky.feed.post` embeds where any image blob exceeds 2,000,000 bytes. Bugsnag has been firing `RuntimeError: Failed to create app.bsky.feed.post record: blob too big (maximum 2000000, got 2036583)` from `Bluesky#create_record` (`app/lib/bluesky.rb:340`) on high-detail 4000px JPEGs, even at quality 60.

Thumbor 7.7.7 (already running in `fly-thumbor`) ships a built-in [`max_bytes(N)`](https://thumbor.readthedocs.io/en/latest/max_bytes.html) filter that iteratively degrades JPEG/WebP quality until the output fits under N bytes — exactly the safeguard needed.

- Add a `:max_bytes` option to `Thumborizable#build_filters` so any caller can request a hard byte cap.
- Apply it to `Photo#bluesky_url` with a target of **1,950,000 bytes** (50KB headroom for Thumbor's quality-step granularity).
- With Thumbor enforcing the size cap, raise the starting JPEG quality from **60 to 80** — images that comfortably fit under the limit now look noticeably better, while oversize images get walked down from 80 by Thumbor until they fit.

## Test plan

- [ ] `docker compose run --rm app bundle exec rspec spec/models/photo_spec.rb spec/lib/bluesky_spec.rb`
- [ ] In a Rails console, confirm the generated URL contains `max_bytes(1950000)`:
      `docker compose run --rm app rails runner 'puts Photo.last.bluesky_url'`
- [ ] After deploy, monitor Bugsnag — the recurring `BlueskyJob` "blob too big" event should stop firing on the next high-detail post.

https://claude.ai/code/session_01Tfv5DCZkXR6MeBZUqqpd31

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tfv5DCZkXR6MeBZUqqpd31)_