### PR TITLE
Update bluesky_url tests to expect quality: 100

### DIFF
--- a/spec/models/photo_spec.rb
+++ b/spec/models/photo_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe Photo, type: :model do
       allow(photo).to receive(:height).and_return(4000)
       allow(photo).to receive(:has_dimensions?).and_return(true)
 
-      expect(photo).to receive(:url).with(hash_including(width: 4000, format: 'jpeg', quality: 80, max_bytes: 1_950_000))
+      expect(photo).to receive(:url).with(hash_including(width: 4000, format: 'jpeg', quality: 100, max_bytes: 1_950_000))
       photo.bluesky_url
     end
 
@@ -195,7 +195,7 @@ RSpec.describe Photo, type: :model do
       allow(photo).to receive(:height).and_return(2000)
       allow(photo).to receive(:has_dimensions?).and_return(true)
 
-      expect(photo).to receive(:url).with(hash_including(width: 3000, format: 'jpeg', quality: 80, max_bytes: 1_950_000))
+      expect(photo).to receive(:url).with(hash_including(width: 3000, format: 'jpeg', quality: 100, max_bytes: 1_950_000))
       photo.bluesky_url
     end
 
@@ -205,7 +205,7 @@ RSpec.describe Photo, type: :model do
       allow(photo).to receive(:has_dimensions?).and_return(true)
 
       expected_width = photo.width_from_height(4000)
-      expect(photo).to receive(:url).with(hash_including(width: expected_width, format: 'jpeg', quality: 80, max_bytes: 1_950_000))
+      expect(photo).to receive(:url).with(hash_including(width: expected_width, format: 'jpeg', quality: 100, max_bytes: 1_950_000))
       photo.bluesky_url
     end
 
@@ -214,7 +214,7 @@ RSpec.describe Photo, type: :model do
       allow(photo).to receive(:height).and_return(3000)
       allow(photo).to receive(:has_dimensions?).and_return(true)
 
-      expect(photo).to receive(:url).with(hash_including(width: 2000, format: 'jpeg', quality: 80, max_bytes: 1_950_000))
+      expect(photo).to receive(:url).with(hash_including(width: 2000, format: 'jpeg', quality: 100, max_bytes: 1_950_000))
       photo.bluesky_url
     end
 
@@ -223,7 +223,7 @@ RSpec.describe Photo, type: :model do
       allow(photo).to receive(:height).and_return(nil)
       allow(photo).to receive(:has_dimensions?).and_return(false)
 
-      expect(photo).to receive(:url).with(hash_including(width: 4000, format: 'jpeg', quality: 80, max_bytes: 1_950_000))
+      expect(photo).to receive(:url).with(hash_including(width: 4000, format: 'jpeg', quality: 100, max_bytes: 1_950_000))
       photo.bluesky_url
     end
   end


### PR DESCRIPTION
## Summary

Commit 667ecb5 raised the JPEG quality used by `Photo#bluesky_url` from 80 to 100, but the corresponding spec expectations in `spec/models/photo_spec.rb` were not updated, leaving five failing tests in the `#bluesky_url` describe block. This updates the `quality:` value in those expectations from `80` to `100` to match the implementation.

## Test plan

- [ ] `docker compose run --rm app bundle exec rspec spec/models/photo_spec.rb -e "bluesky_url"` passes


---
_Generated by [Claude Code](https://claude.ai/code/session_019JEFVHbvyUy1iYqkH1tvp4)_